### PR TITLE
Fix : Handle zero value correctly ( array of array)

### DIFF
--- a/src/modules/convert-array-of-arrays-to-csv.js
+++ b/src/modules/convert-array-of-arrays-to-csv.js
@@ -17,7 +17,7 @@ export const convertArrayOfArraysToCSV = (data, { header, separator }) => {
 
   array.forEach((row) => {
     row.forEach((value, i) => {
-      const thisValue = value || '';
+      const thisValue = value || ((value === 0)?0:'');
       const includesSpecials = checkSpecialCharsAndEmpty(thisValue);
       csv +=
         (includesSpecials ? `"${thisValue}"` : thisValue) +


### PR DESCRIPTION
When converting an array of array of numeric values ( world map storage ) to CSV, we encountered an issue, all zeros where replaced by "", which lead to map corruption.

The fix allow to preserve all 0 numeric values in the generated CSV string.